### PR TITLE
Facilitate the requirements to custom floating-point type (construction)

### DIFF
--- a/include/boost/spirit/home/x3/support/numeric_utils/extract_real.hpp
+++ b/include/boost/spirit/home/x3/support/numeric_utils/extract_real.hpp
@@ -142,7 +142,7 @@ namespace boost { namespace spirit { namespace x3
             bool neg = p.parse_sign(first, last);
 
             // Now attempt to parse an integer
-            T n = 0;
+            T n(0);
             bool got_a_number = p.parse_n(first, last, n);
 
             // If we did not get a number it might be a NaN, Inf or a leading


### PR DESCRIPTION
The change allows the user to provide only an explicit conversion constructor for construction from integral types.
