### PR TITLE
Facilitate the requirements to custom floating-point type (comparison)

### DIFF
--- a/include/boost/spirit/home/x3/support/numeric_utils/extract_real.hpp
+++ b/include/boost/spirit/home/x3/support/numeric_utils/extract_real.hpp
@@ -112,7 +112,7 @@ namespace boost { namespace spirit { namespace x3 { namespace extension
     inline bool
     is_equal_to_one(T const& value)
     {
-        return value == 1.0;
+        return value == T(1);
     }
 
     inline bool


### PR DESCRIPTION
The change allows the user to make custom floating-point type equality comparable only. operator == (double) is not required.
